### PR TITLE
Set default value for final ShortcodeAbstract::render content argument

### DIFF
--- a/lib/Shortcodes/ShortcodeAbstract.php
+++ b/lib/Shortcodes/ShortcodeAbstract.php
@@ -48,5 +48,5 @@ abstract class ShortcodeAbstract {
 	 * @param mixed $content
 	 * @return string
 	 */
-	abstract public function render( $atts = array(), $content ): string;
+	abstract public function render( $atts = array(), $content = '' ): string;
 }

--- a/src/Shortcodes/MW_SSO_Login_Button.php
+++ b/src/Shortcodes/MW_SSO_Login_Button.php
@@ -44,7 +44,7 @@ class MW_SSO_Login_Button extends ShortcodeAbstract {
 	 * @param mixed $content
 	 * @return string
 	 */
-	public function render( $atts = array(), $content ): string {
+	public function render( $atts = array(), $content = '' ): string {
 		$url   = Helpers::get_login_action_url();
 		$label = ! empty( $content ) ? wp_kses_post( $content ) : __( 'Login with MediaWiki' );
 


### PR DESCRIPTION
This brings in a change present in the Diff environment which prevents warnings if render is called without any content parameter.