### PR TITLE
Ensure plugin classes are available in local Composer autoloader classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "stable",
     "require": {
-        "composer/installers": "~1.0",
-        "league/oauth2-client": "^2.6.0"
+        "composer/installers": "^1.10",
+        "league/oauth2-client": "^2.8.1"
     },
     "require-dev": {
         "automattic/vipwpcs": "^3.0",
@@ -25,8 +25,8 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "composer/installers": true
+            "composer/installers": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29b079c3647950c8a7e15a5cd9508e2c",
+    "content-hash": "f30a53255941e8da618a1b7a1d973e7d",
     "packages": [
         {
             "name": "composer/installers",


### PR DESCRIPTION
The build code introduced in #16 did not account for loading the local plugin files into the autoloader classmap, so the `Factory` class is not available on plugin initialization and the plugin fatals.

This PR introduces the two PSR-4 classmap namespaces [that this diff indicates to be missing](https://github.com/wpcomvip/wikimedia-blog-wikimedia-org/commit/bc187c84a3b5f5fc7902f6a6f6820ded06569d1f#diff-bd902393d535fd0ce6ee9e52bd1cbc1017aefcfd94609eaa49e7acdc448af4d5).