### PR TITLE
Prepare release v.1.3.0

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -13,7 +13,7 @@
  * Description:         Provides SSO between your WordPress site and any MediaWiki application with the OAuth extension enabled
  * Author:              <a href="https://wikimediafoundation.org/">Wikimedia Foundation</a>, <a href="https://codeable.io/developers/brad-morris/">Brad Morris (Codeable)</a>, <a href="https://humanmade.com">Human Made</a>
  *
- * Version:             1.2.1
+ * Version:             1.3.0
  * Requires at least:   6.3
  * Tested up to:        6.8.2
  *


### PR DESCRIPTION
Prepares for release 1.3.0, which includes https://github.com/wikimedia/mediawiki-oauth-client-wordpress-plugin/pull/21